### PR TITLE
Re-work implementation to hook into existing code instead of re-implementing chat render logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ repositories {
 	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
 	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
 	// for more information about repositories.
+
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -31,6 +33,8 @@ dependencies {
 	// These are included in the Fabric API production distribution and allow you to update your mod to the latest modules at a later more convenient time.
 
 	// modImplementation "net.fabricmc.fabric-api:fabric-api-deprecated:${project.fabric_version}"
+
+    include(implementation(annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-fabric:0.2.0-beta.9")))
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.1+build.10
 loader_version=0.14.21
 
 # Mod Properties
-mod_version=1.0.2
+mod_version=1.0.3
 maven_group=ezzenix.chatanimation
 archives_base_name=chatanimation
 

--- a/src/main/java/ezzenix/chatanimation/mixin/ChatMixin.java
+++ b/src/main/java/ezzenix/chatanimation/mixin/ChatMixin.java
@@ -3,6 +3,7 @@ package ezzenix.chatanimation.mixin;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.hud.ChatHud;
 import net.minecraft.client.gui.hud.ChatHudLine;
@@ -86,6 +87,15 @@ public class ChatMixin {
 	private float applyYOffset(float y) {
 		// Apply the offset
 		calculateYOffset();
+
+		// Raised mod compatibility
+		if (FabricLoader.getInstance().getObjectShare().get("raised:hud") instanceof Integer distance) {
+			// for Raised 1.2.0+
+			y -= distance;
+		} else if (FabricLoader.getInstance().getObjectShare().get("raised:distance") instanceof Integer distance) {
+			y -= distance;
+		}
+
 		return y + chatDisplacementY;
 	}
 

--- a/src/main/java/ezzenix/chatanimation/mixin/ChatMixin.java
+++ b/src/main/java/ezzenix/chatanimation/mixin/ChatMixin.java
@@ -1,18 +1,23 @@
 package ezzenix.chatanimation.mixin;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.ChatHud;
 import net.minecraft.client.gui.hud.ChatHudLine;
 import net.minecraft.client.gui.hud.MessageIndicator;
 import net.minecraft.network.message.MessageSignatureData;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.MathHelper;
-import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.ArrayList;
@@ -48,114 +53,64 @@ public class ChatMixin {
 	@Unique private final float fadeOffsetYScale = 0.8f; // scale * lineHeight
 	@Unique private final float fadeTime = 130;
 
-	@Inject(method = "render", at = @At("HEAD"), cancellable = true)
-	public void render(DrawContext context, int currentTick, int mouseX, int mouseY, CallbackInfo ci) {
-		int y;
-		int w;
-		int textBackgroundOpacityFinal;
-		int chatOpacityFinal;
-		int ticksAlive;
+	private int chatLineIndex;
+	private int chatDisplacementY = 0;
 
-		if (this.isChatHidden()) {
-			return;
-		}
+	@Inject(method = "render", at = @At(
+		value = "INVOKE",
+		target = "Lnet/minecraft/client/gui/hud/ChatHudLine$Visible;addedTime()I"
+	))
+	public void getChatLineIndex(CallbackInfo ci, @Local(ordinal = 13) int chatLineIndex) {
+		// Capture which chat line is currently being rendered
+		this.chatLineIndex = chatLineIndex;
+	}
 
-		int visibleLineCount = this.getVisibleLineCount();
-		int visibleMessagesCount = this.visibleMessages.size();
-		if (visibleMessagesCount == 0) {
-			return;
-		}
-
-		boolean isFocused = this.isChatFocused();
-		float chatScale = (float)this.getChatScale();
-		int k = MathHelper.ceil((float)this.getWidth() / chatScale);
-		int scaledWindowHeight = context.getScaledWindowHeight();
-
-		context.getMatrices().push();
-		context.getMatrices().scale(chatScale, chatScale, 1.0f);
-		context.getMatrices().translate(4.0f, 0.0f, 0.0f);
-
-		int chatBottomY = MathHelper.floor((float)(scaledWindowHeight - 40) / chatScale);
-		//int n = this.getMessageIndex(this.toChatLineX(mouseX), this.toChatLineY(mouseY));
-		double chatOpacity = this.client.options.getChatOpacity().getValue() * (double)0.9f + (double)0.1f;
-		double textBackgroundOpacity = this.client.options.getTextBackgroundOpacity().getValue();
-		double chatLineSpacing = this.client.options.getChatLineSpacing().getValue();
-		int lineHeight = this.getLineHeight();
-		int lineSpacing = (int)Math.round(-8.0 * (chatLineSpacing + 1.0) + 4.0 * chatLineSpacing);
-		int index = 0;
-		int chatDisplacementY = 0;
-		float maxDisplacement = (float)lineHeight * fadeOffsetYScale;
-
-		for (int r = 0; r + this.scrolledLines < this.visibleMessages.size() && r < visibleLineCount; ++r) {
-			int s = r + this.scrolledLines;
-			ChatHudLine.Visible visible = this.visibleMessages.get(s);
-			if (visible == null || (ticksAlive = currentTick - visible.addedTime()) >= 200 && !isFocused) continue;
-
-			long timestamp = messageTimestamps.get(r);
+	private void calculateYOffset() {
+		// Calculate current required offset to achieve slide in from bottom effect
+		try {
+			int lineHeight = this.getLineHeight();
+			float maxDisplacement = (float)lineHeight * fadeOffsetYScale;
+			long timestamp = messageTimestamps.get(chatLineIndex);
 			long timeAlive = System.currentTimeMillis() - timestamp;
-			if (r == 0 && timeAlive < fadeTime && this.scrolledLines == 0) {
+			if (chatLineIndex == 0 && timeAlive < fadeTime && this.scrolledLines == 0) {
 				chatDisplacementY = (int)(maxDisplacement - ((timeAlive/fadeTime)*maxDisplacement));
 			}
+		} catch (Exception ignored) {}
+	}
 
-			double opacity = isFocused ? 1.0 : getMessageOpacityMultiplier(ticksAlive);
+	@ModifyArg(method = "render", index = 1, at = @At(
+		value = "INVOKE",
+		target = "Lnet/minecraft/client/util/math/MatrixStack;translate(FFF)V",
+		ordinal = 1
+	))
+	private float applyYOffset(float y) {
+		// Apply the offset
+		calculateYOffset();
+		return y + chatDisplacementY;
+	}
+
+	@ModifyVariable(method = "render", ordinal = 3, at = @At(
+		value = "STORE"
+	))
+	private double modifyOpacity(double originalOpacity) {
+		double opacity = originalOpacity;
+		// Calculate current required opacity for currently rendered line to achieve fade in effect
+		try {
+			long timestamp = messageTimestamps.get(chatLineIndex);
+			long timeAlive = System.currentTimeMillis() - timestamp;
 			if (timeAlive < fadeTime && this.scrolledLines == 0) {
 				opacity = opacity * (0.5 + MathHelper.clamp(timeAlive/fadeTime, 0, 1)/2);
 			}
+		} catch (Exception ignored) {}
+		return opacity;
+	}
 
-			chatOpacityFinal = (int)(255.0 * opacity * chatOpacity);
-			textBackgroundOpacityFinal = (int)(255.0 * opacity * textBackgroundOpacity);
-			++index;
-
-			if (chatOpacityFinal <= 3) continue;
-
-			y = chatBottomY - r * lineHeight + chatDisplacementY;
-			context.getMatrices().push();
-			context.getMatrices().translate(0.0f, 0.0f, 50.0f);
-			context.fill(-4, y - lineHeight, k + 4 + 4, y, textBackgroundOpacityFinal << 24);
-			/*
-			MessageIndicator messageIndicator = visible.indicator();
-			if (messageIndicator != null) {
-				int z = messageIndicator.indicatorColor() | u << 24;
-				context.fill(-4, x - lineHeight, -2, x, z);
-				if (s == n && messageIndicator.icon() != null) {
-					int aa = this.getIndicatorX(visible);
-					int ab = y + this.client.textRenderer.fontHeight;
-					this.drawIndicatorIcon(context, aa, ab, messageIndicator.icon());
-				}
-			}
-			*/
-			context.getMatrices().translate(0.0f, 0.0f, 50.0f);
-			context.drawTextWithShadow(this.client.textRenderer, visible.content(), 0, y + lineSpacing, 0xFFFFFF + (chatOpacityFinal << 24));
-			context.getMatrices().pop();
-		}
-		long ac = this.client.getMessageHandler().getUnprocessedMessageCount();
-		if (ac > 0L) {
-			int ad = (int)(128.0 * chatOpacity);
-			ticksAlive = (int)(255.0 * textBackgroundOpacity);
-			context.getMatrices().push();
-			context.getMatrices().translate(0.0f, chatBottomY, 50.0f);
-			context.fill(-2, 0, k + 4, 9, ticksAlive << 24);
-			context.getMatrices().translate(0.0f, 0.0f, 50.0f);
-			context.drawTextWithShadow(this.client.textRenderer, Text.translatable("chat.queue", ac), 0, 1, 0xFFFFFF + (ad << 24));
-			context.getMatrices().pop();
-		}
-		if (isFocused) {
-			int ad = this.getLineHeight();
-			ticksAlive = visibleMessagesCount * ad;
-			int ae = index * ad;
-			int af = this.scrolledLines * ae / visibleMessagesCount - chatBottomY;
-			chatOpacityFinal = ae * ae / ticksAlive;
-			if (ticksAlive != ae) {
-				textBackgroundOpacityFinal = af > 0 ? 170 : 96;
-				w = this.hasUnreadNewMessages ? 0xCC3333 : 0x3333AA;
-				int x = k + 4;
-				context.fill(x, -af, x + 2, -af - chatOpacityFinal, w + (textBackgroundOpacityFinal << 24));
-				context.fill(x + 2, -af, x + 1, -af - chatOpacityFinal, 0xCCCCCC + (textBackgroundOpacityFinal << 24));
-			}
-		}
-		context.getMatrices().pop();
-
-		ci.cancel();
+	@ModifyVariable(method = "render", at = @At(
+			value = "STORE"
+	))
+	private MessageIndicator removeMessageIndicator(MessageIndicator messageIndicator) {
+		// Don't allow the chat indicator bar to be rendered
+		return null;
 	}
 
 	@Inject(method = "addMessage(Lnet/minecraft/text/Text;Lnet/minecraft/network/message/MessageSignatureData;ILnet/minecraft/client/gui/hud/MessageIndicator;Z)V", at = @At("TAIL"))


### PR DESCRIPTION
Fixes #1 
Fixes #2

This allows other mods to modify chat rendering as well, without ChatAnimation completely overriding all rendering logic.
Add compatibility with Raised mod

Bump version to 1.0.3

Build in case anyone needs it:
https://github.com/TheMrEngMan/ChatAnimation/releases/tag/1.0.3
