### PR TITLE
Fix missing popPose when chat is empty or hidden

### DIFF
--- a/common/src/main/java/com/ezzenix/chatanimation/mixin/ChatComponentMixin.java
+++ b/common/src/main/java/com/ezzenix/chatanimation/mixin/ChatComponentMixin.java
@@ -44,7 +44,7 @@ public class ChatComponentMixin {
 		context.pose().translate(0f, displacement, 0f);
 	}
 
-	@Inject(method = "render", at = @At("TAIL"))
+	@Inject(method = "render", at = @At("RETURN"))
 	private void onRenderEnd(GuiGraphics context, int currentTick, int mouseX, int mouseY, boolean focused, CallbackInfo ci) {
 		context.pose().popPose();
 	}


### PR DESCRIPTION
Fixes #28 

Testings:

1. Confirmed correctness by inspecting the output class with `-Dmixin.debug.export=true`
2. Previously, when used in combination with Gnetum, the HUD would flicker when the chat is empty; this PR resolves it.